### PR TITLE
Configure addon to work with >= Node 4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const opn = require('opn');
-const cleanBaseURL = require('clean-base-url');
+var opn = require('opn');
+var cleanBaseURL = require('clean-base-url');
 
 module.exports = {
   name: 'ember-open-browser',
@@ -12,17 +12,19 @@ module.exports = {
   detectBrowser() {
     return process.env.BROWSER;
   },
-  
+
   createUri(options) {
-    const baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
-    
+    var baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+
     return `http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
   },
 
-  serverMiddleware({ options }) {
+  serverMiddleware(config) {
+    var options = config.options;
+
     if (options.watcher.serving && this._browser !== 'none' && !options.noBrowser) {
-      const uri = options['open-browser-uri'] || this.createUri(options);
-      const opnOptions = this._browser ? { app: this._browser } : {};
+      var uri = options['open-browser-uri'] || this.createUri(options);
+      var opnOptions = this._browser ? { app: this._browser } : {};
 
       options.watcher.watcher.once('change', () => opn(uri, opnOptions));
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var opn = require('opn');
-var cleanBaseURL = require('clean-base-url');
+const opn = require('opn');
+const cleanBaseURL = require('clean-base-url');
 
 module.exports = {
   name: 'ember-open-browser',
@@ -14,17 +14,17 @@ module.exports = {
   },
 
   createUri(options) {
-    var baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
+    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
 
     return `http${options.ssl ? 's' : ''}://${options.host || 'localhost'}:${options.port}${baseURL}`;
   },
 
   serverMiddleware(config) {
-    var options = config.options;
+    let options = config.options;
 
     if (options.watcher.serving && this._browser !== 'none' && !options.noBrowser) {
-      var uri = options['open-browser-uri'] || this.createUri(options);
-      var opnOptions = this._browser ? { app: this._browser } : {};
+      let uri = options['open-browser-uri'] || this.createUri(options);
+      let opnOptions = this._browser ? { app: this._browser } : {};
 
       options.watcher.watcher.once('change', () => opn(uri, opnOptions));
     }


### PR DESCRIPTION
SEE: https://github.com/ember-cli/ember-cli/pull/7026

This addon will break other consuming addons/apps which are doing all CI testing against Node >= v4.x - See my current build failure https://travis-ci.org/alexdiliberto/ember-cli-transformicons/jobs/257576872.

This PR will address the issue by making this addon backwards compatible to Node 4.x

After this gets merged, please cut a new release. 👍 