### PR TITLE
Invoking script-level Strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const opn = require('opn');
 const cleanBaseURL = require('clean-base-url');
 


### PR DESCRIPTION
Still getting errors using Node 4x without strict mode after you updated my [original PR](https://github.com/jasonmit/ember-open-browser/pull/2) to use `let` and `const`. This PR fixes the issue.

Please cut a new release after this is merged. Thanks  👍 

Before PR:
```sh
alexdiliberto@AlexBookPro: ~/Repos/temp/ember-open-browser on patch-1
$ node --version
v4.8.3

alexdiliberto@AlexBookPro: ~/Repos/temp/ember-open-browser on patch-1
$ node index.js 
/Users/alexdiliberto/Repos/temp/ember-open-browser/index.js:17
    let baseURL = options.rootURL === '' ? '/' : cleanBaseURL(options.rootURL || options.baseURL);
    ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```

After PR:
```sh
alexdiliberto@AlexBookPro: ~/Repos/temp/ember-open-browser on patch-1
$ node --version
v4.8.3

alexdiliberto@AlexBookPro: ~/Repos/temp/ember-open-browser on patch-1
$ node index.js
```